### PR TITLE
feat: Reverse cycle through widgets with shift+tab

### DIFF
--- a/src/azure_keyvault_browser/renderables/help.py
+++ b/src/azure_keyvault_browser/renderables/help.py
@@ -24,6 +24,8 @@ class HelpRenderable:
             "previous row": f"{UP}",
             "next page": f"{RIGHT}",
             "previous page": f"{LEFT}",
+            "next widget": Keys.Tab,
+            "previous widget": Keys.BackTab,
             "first page": "f",
             "last page": "l",
             "select": Keys.Enter,


### PR DESCRIPTION
I found myself wanting to hit shift+tab to navigate back to the previous widget.

A double-ended queue seemed like a neat way of doing it.